### PR TITLE
save widget state

### DIFF
--- a/jupyterbook/content/code_gallery/data_management_notebooks/2020-10-10-GTS.ipynb
+++ b/jupyterbook/content/code_gallery/data_management_notebooks/2020-10-10-GTS.ipynb
@@ -706,7 +706,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The map on this notebook was not showing up. Every time we update a notebook with a widget we must save the widget state and "trust notebook" before publishing it.