### PR TITLE
libmamba is no longer experimental

### DIFF
--- a/jupyterbook/content/ioos_installation_conda.md
+++ b/jupyterbook/content/ioos_installation_conda.md
@@ -52,7 +52,7 @@ This make the faster mamba solver default in our installations.
 
 ```
 conda install --name base conda-libmamba-solver --yes
-conda config --set experimental_solver libmamba
+conda config --set solver libmamba
 ```
 
 If that worked you should see:


### PR DESCRIPTION
This is default in conda >=2.11.1