### PR TITLE
fix some typos

### DIFF
--- a/jupyterbook/content/code_gallery/data_access_notebooks/2016-12-22-boston_light_swim.ipynb
+++ b/jupyterbook/content/code_gallery/data_access_notebooks/2016-12-22-boston_light_swim.ipynb
@@ -938,7 +938,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the root mean squared rrror of the deviations from the mean:\n",
+    "And the root mean squared error of the deviations from the mean:\n",
     "$$ \\\\text{CRMS} = \\\\sqrt{\\\\left(\\\\mathbf{m'} - \\\\mathbf{o'}\\\\right)^2}$$\n",
     "\n",
     "where: $\\\\mathbf{m'} = \\\\mathbf{m} - \\\\mathbf{\\\\overline{m}}$ and $\\\\mathbf{o'} = \\\\mathbf{o} - \\\\mathbf{\\\\overline{o}}$"

--- a/jupyterbook/content/code_gallery/data_access_notebooks/2017-11-30-rerddap.ipynb
+++ b/jupyterbook/content/code_gallery/data_access_notebooks/2017-11-30-rerddap.ipynb
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By inspecting the information above we can find the variables available in the dateset and use  the `tabledap` function to download them.\n",
+    "By inspecting the information above we can find the variables available in the dataset and use  the `tabledap` function to download them.\n",
     "\n",
     "Note that the `%%R -o rdf` will export the `rdf` variable back to the Python workspace."
    ]
@@ -1075,7 +1075,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/jupyterbook/content/code_gallery/data_access_notebooks/2020-10-10-GTS.ipynb
+++ b/jupyterbook/content/code_gallery/data_access_notebooks/2020-10-10-GTS.ipynb
@@ -259,7 +259,7 @@
     "id": "5oP7aFrErtWX"
    },
    "source": [
-    "Let us check the montly sum of data released both for individual met and wave and the totals."
+    "Let us check the monthly sum of data released both for individual met and wave and the totals."
    ]
   },
   {
@@ -387,9 +387,9 @@
     "id": "Pt3yasWfrtWa"
    },
    "source": [
-    "Those plots are intersting to understand the RAs role in the GTS ingest and how much data is being released over time. It would be nice to see those per buoy on a map.\n",
+    "Those plots are interesting to understand the RAs role in the GTS ingest and how much data is being released over time. It would be nice to see those per buoy on a map.\n",
     "\n",
-    "For that we need to get the position of the NDBC buoys. Let's get a table of all the buoys and match with what we have in teh GTS data."
+    "For that we need to get the position of the NDBC buoys. Let's get a table of all the buoys and match with what we have in the GTS data."
    ]
   },
   {
@@ -710,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.0"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/jupyterbook/content/code_gallery/data_analysis_and_visualization_notebooks/2021-10-25-ERDDAP-interpolate.ipynb
+++ b/jupyterbook/content/code_gallery/data_analysis_and_visualization_notebooks/2021-10-25-ERDDAP-interpolate.ipynb
@@ -191,7 +191,7 @@
     "from urllib.parse import quote_plus\n",
     "\n",
     "# See https://coastwatch.pfeg.noaa.gov/erddap/convert/interpolate.html\n",
-    "# for more infor on the options available\n",
+    "# for more info on the options available\n",
     "response = \"csv\"\n",
     "dataset_id = \"jplMURSST41\"\n",
     "variable = \"analysed_sst\"\n",
@@ -371,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We cannot run codespell cleanly on notebooks yet but we can do:

```
for nb in **/*.ipynb ; do echo "${nb}"; cat "${nb}" | jupytext --from ipynb --to py:percent | codespell -; done 2>&1 | tee log
```

to convert with jupytext and run on the result.