### PR TITLE
Added pyarrow to the environment files

### DIFF
--- a/.binder/environment-python_and_r.yml
+++ b/.binder/environment-python_and_r.yml
@@ -44,6 +44,7 @@ dependencies:
   - phantomjs
   - pocean-core >=3.1
   - pre-commit
+  - pyarrow
   - pyobis
   - pyoos
   - pyresample

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -43,6 +43,7 @@ dependencies:
   - phantomjs
   - pocean-core >=3.1
   - pre-commit
+  - pyarrow
   - pyobis
   - pyoos
   - pyresample


### PR DESCRIPTION
I added pyarrow to both of the environment files because when I was testing the CodeLab modules, I kept getting a deprecation warning that soon pyarrow will be required for pandas. This update to the environment fixed the issue when I tested it.