### PR TITLE
This GHA should not try to publish

### DIFF
--- a/.github/workflows/docs-linkchecker.yml
+++ b/.github/workflows/docs-linkchecker.yml
@@ -28,10 +28,3 @@ jobs:
           set -e
           && pip install jupyter-book
           && jupyter-book build jupyterbook --builder linkcheck
-
-      - name: GitHub Pages action
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: jupyterbook/_build/html


### PR DESCRIPTION
Continuation of #286. I missed that the linkrot check also had the GHA to publish! We don't need that.